### PR TITLE
Support for different PWM pins and the Mega 2560

### DIFF
--- a/DualVNH5019MotorShield/DualVNH5019MotorShield.cpp
+++ b/DualVNH5019MotorShield/DualVNH5019MotorShield.cpp
@@ -9,14 +9,19 @@ DualVNH5019MotorShield::DualVNH5019MotorShield()
   _INB1 = 4;
   _EN1DIAG1 = 6;
   _CS1 = A0; 
+  _PWM1 = 9;
   _INA2 = 7;
   _INB2 = 8;
   _EN2DIAG2 = 12;
   _CS2 = A1;
+  _PWM2 = 10;
 }
 
-DualVNH5019MotorShield::DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, unsigned char EN1DIAG1, unsigned char CS1, 
-                                               unsigned char INA2, unsigned char INB2, unsigned char EN2DIAG2, unsigned char CS2)
+DualVNH5019MotorShield::DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, 
+											   unsigned char EN1DIAG1, unsigned char CS1, 
+                                               unsigned char INA2, unsigned char PWM1,
+											   unsigned char INB2, unsigned char EN2DIAG2, 
+											   unsigned char CS2, unsigned char PWM2)
 {
   //Pin map
   //PWM1 and PWM2 cannot be remapped because the library assumes PWM is on timer1
@@ -24,10 +29,12 @@ DualVNH5019MotorShield::DualVNH5019MotorShield(unsigned char INA1, unsigned char
   _INB1 = INB1;
   _EN1DIAG1 = EN1DIAG1;
   _CS1 = CS1;
+  _PWM1 = PWM1;
   _INA2 = INA2;
   _INB2 = INB2;
   _EN2DIAG2 = EN2DIAG2;
   _CS2 = CS2;
+  _PWM2 = PWM2;
 }
 
 // Public Methods //////////////////////////////////////////////////////////////
@@ -45,6 +52,11 @@ void DualVNH5019MotorShield::init()
   pinMode(_PWM2,OUTPUT);
   pinMode(_EN2DIAG2,INPUT);
   pinMode(_CS2,INPUT);
+  
+  // initialize the register pointers to null. If not set we will use analogWrite
+  _PWM1_REG = NULL; 
+  _PWM2_REG = NULL;
+  
   #if defined(__AVR_ATmega168__)|| defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__)
   // Timer 1 configuration
   // prescaler: clockI/O / 1
@@ -54,9 +66,88 @@ void DualVNH5019MotorShield::init()
   //
   // PWM frequency calculation
   // 16MHz / 1 (prescaler) / 2 (phase-correct) / 400 (top) = 20kHz
-  TCCR1A = 0b10100000;
-  TCCR1B = 0b00010001;
-  ICR1 = 400;
+  if(_PWM1 == 9 || _PWM1 == 10 || _PWM2 == 9 || _PWM2 == 10)
+  {
+    if(_PWM1 == 9)       { TCCR1A |= COM1A1; _PWM1_REG = &OCR1A; }
+	else if(_PWM1 == 10) { TCCR1A |= COM1B1; _PWM1_REG = &OCR1B; }
+	
+	if(_PWM2 == 9)       { TCCR1A |= COM1A1; _PWM2_REG = &OCR1A; }
+	else if(_PWM2 == 10) { TCCR1A |= COM1B1; _PWM2_REG = &OCR1B; }
+  
+	TCCR1A = COM1A1 + COM1B1;
+	TCCR1B = WGM13 + CS10;
+	ICR1 = 400;
+  }
+  /* ------------------------------- FOR THE MEGA ------------------------- */
+  #elif defined(__AVR_ATmega2560__) 
+  if(_PWM1 == 11 || _PWM1 == 12 || _PWM1 == 13 || 
+     _PWM2 == 11 || _PWM2 == 12 || _PWM2 == 13)
+  {
+    //timer1
+	TCCR1A = 0;
+	if(_PWM1 == 11)      { TCCR1A |= COM1A1; _PWM1_REG = &OCR1A; }
+	else if(_PWM1 == 12) { TCCR1A |= COM1B1; _PWM1_REG = &OCR1B; }
+	else if(_PWM1 == 13) { TCCR1A |= COM1C1; _PWM1_REG = &OCR1C; }
+	
+	if(_PWM2 == 11)      { TCCR1A |= COM1A1; _PWM2_REG = &OCR1A; }
+	else if(_PWM2 == 12) { TCCR1A |= COM1B1; _PWM2_REG = &OCR1B; }
+	else if(_PWM2 == 13) { TCCR1A |= COM1C1; _PWM2_REG = &OCR1C; }
+	
+	//TCCR1A = COM1A1 + COM1B1 + COM1C1;
+    TCCR1B = WGM13 + CS10;
+    ICR1 = 400;
+  }
+  else if(_PWM1 == 2 || _PWM1 == 3 || _PWM1 == 5 || 
+          _PWM2 == 2 || _PWM2 == 3 || _PWM2 == 5)
+  {
+    //timer3
+	TCCR3A = 0;
+	if(_PWM1 == 5)      { TCCR3A |= COM3A1; _PWM1_REG = &OCR3A; }
+	else if(_PWM1 == 2) { TCCR3A |= COM3B1; _PWM1_REG = &OCR3B; }
+	else if(_PWM1 == 3) { TCCR3A |= COM3C1; _PWM1_REG = &OCR3C; }
+	
+	if(_PWM2 == 5)      { TCCR3A |= COM3A1; _PWM2_REG = &OCR3A; }
+	else if(_PWM2 == 2) { TCCR3A |= COM3B1; _PWM2_REG = &OCR3B; }
+	else if(_PWM2 == 3) { TCCR3A |= COM3C1; _PWM2_REG = &OCR3C; }
+	
+	//TCCR3A = COM3A1 + COM3B1 + COM3C1;
+    TCCR3B = WGM33 + CS30;
+    ICR3 = 400;
+  }
+  else if(_PWM1 == 6 || _PWM1 == 7 || _PWM1 == 8 || 
+          _PWM2 == 6 || _PWM2 == 7 || _PWM2 == 8)
+  {
+    //timer4  
+	TCCR4A = 0;
+	if(_PWM1 == 6)      { TCCR4A |= COM4A1; _PWM1_REG = &OCR4A; }
+	else if(_PWM1 == 7) { TCCR4A |= COM4B1; _PWM1_REG = &OCR4B; }
+	else if(_PWM1 == 8) { TCCR4A |= COM4C1; _PWM1_REG = &OCR4C; }
+	
+	if(_PWM2 == 6)      { TCCR4A |= COM4A1; _PWM2_REG = &OCR4A; }
+	else if(_PWM2 == 7) { TCCR4A |= COM4B1; _PWM2_REG = &OCR4B; }
+	else if(_PWM2 == 8) { TCCR4A |= COM4C1; _PWM2_REG = &OCR4C; }
+	
+	//TCCR4A = COM4A1 + COM4B1 + COM4C1;
+    TCCR4B = WGM43 + CS40;
+    ICR4 = 400;
+  }  
+  else if(_PWM1 == 44 || _PWM1 == 45 || _PWM1 == 46 || 
+          _PWM2 == 44 || _PWM2 == 45 || _PWM2 == 46)
+  {
+	//timer5
+	TCCR5A = 0;
+	if(_PWM1 == 46)      { TCCR5A |= COM5A1; _PWM1_REG = &OCR5A; }
+	else if(_PWM1 == 45) { TCCR5A |= COM5B1; _PWM1_REG = &OCR5B; }
+	else if(_PWM1 == 44) { TCCR5A |= COM5C1; _PWM1_REG = &OCR5C; }
+	
+	if(_PWM2 == 46)      { TCCR5A |= COM5A1; _PWM2_REG = &OCR5A; }
+	else if(_PWM2 == 45) { TCCR5A |= COM5B1; _PWM2_REG = &OCR5B; }
+	else if(_PWM2 == 44) { TCCR5A |= COM5C1; _PWM2_REG = &OCR5C; }
+	
+	//TCCR5A = COM5A1 + COM5B1 + COM5C1;
+    TCCR5B = WGM53 + CS50;
+    ICR5 = 400;
+  }
   #endif
 }
 // Set speed for motor 1, speed is a number betwenn -400 and 400
@@ -71,11 +162,12 @@ void DualVNH5019MotorShield::setM1Speed(int speed)
   }
   if (speed > 400)  // Max PWM dutycycle
     speed = 400;
-  #if defined(__AVR_ATmega168__)|| defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__)
-  OCR1A = speed;
-  #else
-  analogWrite(_PWM1,speed * 51 / 80); // default to using analogWrite, mapping 400 to 255
-  #endif
+  if(_PWM1_REG) {
+	*_PWM1_REG = speed; // if the register is set then use the timers
+  } else {
+	analogWrite(_PWM1,speed * 51 / 80); // default to using analogWrite, mapping 400 to 255
+  }
+
   if (speed == 0)
   {
     digitalWrite(_INA1,LOW);   // Make the motor coast no
@@ -105,11 +197,13 @@ void DualVNH5019MotorShield::setM2Speed(int speed)
   }
   if (speed > 400)  // Max 
     speed = 400;
-  #if defined(__AVR_ATmega168__)|| defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__)
-  OCR1B = speed;
-  #else
-  analogWrite(_PWM2,speed * 51 / 80); // default to using analogWrite, mapping 400 to 255
-  #endif 
+
+  if(_PWM2_REG) {
+	*_PWM2_REG = speed; // if the register is set then use the timers
+  } else {
+	analogWrite(_PWM1,speed * 51 / 80); // default to using analogWrite, mapping 400 to 255
+  }
+	
   if (speed == 0)
   {
     digitalWrite(_INA2,LOW);   // Make the motor coast no
@@ -146,11 +240,11 @@ void DualVNH5019MotorShield::setM1Brake(int brake)
     brake = 400;
   digitalWrite(_INA1, LOW);
   digitalWrite(_INB1, LOW);
-  #if defined(__AVR_ATmega168__)|| defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__)
-  OCR1A = brake;
-  #else
-  analogWrite(_PWM1,brake * 51 / 80); // default to using analogWrite, mapping 400 to 255
-  #endif
+  if(_PWM1_REG) {
+	*_PWM1_REG = brake; // if the register is set then use the timers
+  } else {
+	analogWrite(_PWM1,brake * 51 / 80); // default to using analogWrite, mapping 400 to 255
+  }
 }
 
 // Brake motor 2, brake is a number between 0 and 400
@@ -165,11 +259,11 @@ void DualVNH5019MotorShield::setM2Brake(int brake)
     brake = 400;
   digitalWrite(_INA2, LOW);
   digitalWrite(_INB2, LOW);
-  #if defined(__AVR_ATmega168__)|| defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__)
-  OCR1B = brake;
-  #else
-  analogWrite(_PWM2,brake * 51 / 80); // default to using analogWrite, mapping 400 to 255
-  #endif
+  if(_PWM1_REG) {
+	*_PWM1_REG = brake; // if the register is set then use the timers
+  } else {
+	analogWrite(_PWM1,brake * 51 / 80); // default to using analogWrite, mapping 400 to 255
+  }
 }
 
 // Brake motor 1 and 2, brake is a number between 0 and 400

--- a/DualVNH5019MotorShield/DualVNH5019MotorShield.cpp
+++ b/DualVNH5019MotorShield/DualVNH5019MotorShield.cpp
@@ -68,14 +68,15 @@ void DualVNH5019MotorShield::init()
   // 16MHz / 1 (prescaler) / 2 (phase-correct) / 400 (top) = 20kHz
   if(_PWM1 == 9 || _PWM1 == 10 || _PWM2 == 9 || _PWM2 == 10)
   {
-    if(_PWM1 == 9)       { TCCR1A |= COM1A1; _PWM1_REG = &OCR1A; }
-	else if(_PWM1 == 10) { TCCR1A |= COM1B1; _PWM1_REG = &OCR1B; }
+	TCCR1A = 0;
+    if(_PWM1 == 9)       { TCCR1A |= _BV(COM1A1); _PWM1_REG = &OCR1A; }
+	else if(_PWM1 == 10) { TCCR1A |= _BV(COM1B1); _PWM1_REG = &OCR1B; }
 	
-	if(_PWM2 == 9)       { TCCR1A |= COM1A1; _PWM2_REG = &OCR1A; }
-	else if(_PWM2 == 10) { TCCR1A |= COM1B1; _PWM2_REG = &OCR1B; }
+	if(_PWM2 == 9)       { TCCR1A |= _BV(COM1A1); _PWM2_REG = &OCR1A; }
+	else if(_PWM2 == 10) { TCCR1A |= _BV(COM1B1); _PWM2_REG = &OCR1B; }
   
-	TCCR1A = COM1A1 + COM1B1;
-	TCCR1B = WGM13 + CS10;
+	//TCCR1A = _BV(COM1A1) + _BV(COM1B1);
+	TCCR1B = _BV(WGM13) + _BV(CS10);
 	ICR1 = 400;
   }
   /* ------------------------------- FOR THE MEGA ------------------------- */
@@ -85,16 +86,16 @@ void DualVNH5019MotorShield::init()
   {
     //timer1
 	TCCR1A = 0;
-	if(_PWM1 == 11)      { TCCR1A |= COM1A1; _PWM1_REG = &OCR1A; }
-	else if(_PWM1 == 12) { TCCR1A |= COM1B1; _PWM1_REG = &OCR1B; }
-	else if(_PWM1 == 13) { TCCR1A |= COM1C1; _PWM1_REG = &OCR1C; }
+	if(_PWM1 == 11)      { TCCR1A |= _BV(COM1A1); _PWM1_REG = &OCR1A; }
+	else if(_PWM1 == 12) { TCCR1A |= _BV(COM1B1); _PWM1_REG = &OCR1B; }
+	else if(_PWM1 == 13) { TCCR1A |= _BV(COM1C1); _PWM1_REG = &OCR1C; }
 	
-	if(_PWM2 == 11)      { TCCR1A |= COM1A1; _PWM2_REG = &OCR1A; }
-	else if(_PWM2 == 12) { TCCR1A |= COM1B1; _PWM2_REG = &OCR1B; }
-	else if(_PWM2 == 13) { TCCR1A |= COM1C1; _PWM2_REG = &OCR1C; }
+	if(_PWM2 == 11)      { TCCR1A |= _BV(COM1A1); _PWM2_REG = &OCR1A; }
+	else if(_PWM2 == 12) { TCCR1A |= _BV(COM1B1); _PWM2_REG = &OCR1B; }
+	else if(_PWM2 == 13) { TCCR1A |= _BV(COM1C1); _PWM2_REG = &OCR1C; }
 	
-	//TCCR1A = COM1A1 + COM1B1 + COM1C1;
-    TCCR1B = WGM13 + CS10;
+	//TCCR1A = _BV(COM1A1) + _BV(COM1B1) + _BV(COM1C1);
+    TCCR1B = _BV(WGM13) + _BV(CS10);
     ICR1 = 400;
   }
   else if(_PWM1 == 2 || _PWM1 == 3 || _PWM1 == 5 || 
@@ -102,16 +103,16 @@ void DualVNH5019MotorShield::init()
   {
     //timer3
 	TCCR3A = 0;
-	if(_PWM1 == 5)      { TCCR3A |= COM3A1; _PWM1_REG = &OCR3A; }
-	else if(_PWM1 == 2) { TCCR3A |= COM3B1; _PWM1_REG = &OCR3B; }
-	else if(_PWM1 == 3) { TCCR3A |= COM3C1; _PWM1_REG = &OCR3C; }
+	if(_PWM1 == 5)      { TCCR3A |= _BV(COM3A1); _PWM1_REG = &OCR3A; }
+	else if(_PWM1 == 2) { TCCR3A |= _BV(COM3B1); _PWM1_REG = &OCR3B; }
+	else if(_PWM1 == 3) { TCCR3A |= _BV(COM3C1); _PWM1_REG = &OCR3C; }
 	
-	if(_PWM2 == 5)      { TCCR3A |= COM3A1; _PWM2_REG = &OCR3A; }
-	else if(_PWM2 == 2) { TCCR3A |= COM3B1; _PWM2_REG = &OCR3B; }
-	else if(_PWM2 == 3) { TCCR3A |= COM3C1; _PWM2_REG = &OCR3C; }
+	if(_PWM2 == 5)      { TCCR3A |= _BV(COM3A1); _PWM2_REG = &OCR3A; }
+	else if(_PWM2 == 2) { TCCR3A |= _BV(COM3B1); _PWM2_REG = &OCR3B; }
+	else if(_PWM2 == 3) { TCCR3A |= _BV(COM3C1); _PWM2_REG = &OCR3C; }
 	
-	//TCCR3A = COM3A1 + COM3B1 + COM3C1;
-    TCCR3B = WGM33 + CS30;
+	//TCCR3A = _BV(COM3A1) + _BV(COM3B1) + _BV(COM3C1);
+    TCCR3B = _BV(WGM33) + _BV(CS30);
     ICR3 = 400;
   }
   else if(_PWM1 == 6 || _PWM1 == 7 || _PWM1 == 8 || 
@@ -119,16 +120,16 @@ void DualVNH5019MotorShield::init()
   {
     //timer4  
 	TCCR4A = 0;
-	if(_PWM1 == 6)      { TCCR4A |= COM4A1; _PWM1_REG = &OCR4A; }
-	else if(_PWM1 == 7) { TCCR4A |= COM4B1; _PWM1_REG = &OCR4B; }
-	else if(_PWM1 == 8) { TCCR4A |= COM4C1; _PWM1_REG = &OCR4C; }
+	if(_PWM1 == 6)      { TCCR4A |= _BV(COM4A1); _PWM1_REG = &OCR4A; }
+	else if(_PWM1 == 7) { TCCR4A |= _BV(COM4B1); _PWM1_REG = &OCR4B; }
+	else if(_PWM1 == 8) { TCCR4A |= _BV(COM4C1); _PWM1_REG = &OCR4C; }
 	
-	if(_PWM2 == 6)      { TCCR4A |= COM4A1; _PWM2_REG = &OCR4A; }
-	else if(_PWM2 == 7) { TCCR4A |= COM4B1; _PWM2_REG = &OCR4B; }
-	else if(_PWM2 == 8) { TCCR4A |= COM4C1; _PWM2_REG = &OCR4C; }
+	if(_PWM2 == 6)      { TCCR4A |= _BV(COM4A1); _PWM2_REG = &OCR4A; }
+	else if(_PWM2 == 7) { TCCR4A |= _BV(COM4B1); _PWM2_REG = &OCR4B; }
+	else if(_PWM2 == 8) { TCCR4A |= _BV(COM4C1); _PWM2_REG = &OCR4C; }
 	
-	//TCCR4A = COM4A1 + COM4B1 + COM4C1;
-    TCCR4B = WGM43 + CS40;
+	//TCCR4A = _BV(COM4A1) + _BV(COM4B1) + _BV(COM4C1);
+    TCCR4B = _BV(WGM43) + _BV(CS40);
     ICR4 = 400;
   }  
   else if(_PWM1 == 44 || _PWM1 == 45 || _PWM1 == 46 || 
@@ -136,16 +137,16 @@ void DualVNH5019MotorShield::init()
   {
 	//timer5
 	TCCR5A = 0;
-	if(_PWM1 == 46)      { TCCR5A |= COM5A1; _PWM1_REG = &OCR5A; }
-	else if(_PWM1 == 45) { TCCR5A |= COM5B1; _PWM1_REG = &OCR5B; }
-	else if(_PWM1 == 44) { TCCR5A |= COM5C1; _PWM1_REG = &OCR5C; }
+	if(_PWM1 == 46)      { TCCR5A |= _BV(COM5A1); _PWM1_REG = &OCR5A; }
+	else if(_PWM1 == 45) { TCCR5A |= _BV(COM5B1); _PWM1_REG = &OCR5B; }
+	else if(_PWM1 == 44) { TCCR5A |= _BV(COM5C1); _PWM1_REG = &OCR5C; }
 	
-	if(_PWM2 == 46)      { TCCR5A |= COM5A1; _PWM2_REG = &OCR5A; }
-	else if(_PWM2 == 45) { TCCR5A |= COM5B1; _PWM2_REG = &OCR5B; }
-	else if(_PWM2 == 44) { TCCR5A |= COM5C1; _PWM2_REG = &OCR5C; }
+	if(_PWM2 == 46)      { TCCR5A |= _BV(COM5A1); _PWM2_REG = &OCR5A; }
+	else if(_PWM2 == 45) { TCCR5A |= _BV(COM5B1); _PWM2_REG = &OCR5B; }
+	else if(_PWM2 == 44) { TCCR5A |= _BV(COM5C1); _PWM2_REG = &OCR5C; }
 	
-	//TCCR5A = COM5A1 + COM5B1 + COM5C1;
-    TCCR5B = WGM53 + CS50;
+	//TCCR5A = _BV(COM5A1) + _BV(COM5B1)51/ + _BV(COM5C1);
+    TCCR5B = _BV(WGM53) + _BV(CS50);
     ICR5 = 400;
   }
   #endif
@@ -165,7 +166,7 @@ void DualVNH5019MotorShield::setM1Speed(int speed)
   if(_PWM1_REG) {
 	*_PWM1_REG = speed; // if the register is set then use the timers
   } else {
-	analogWrite(_PWM1,speed * 51 / 80); // default to using analogWrite, mapping 400 to 255
+	analogWrite(_PWM1,speed * 0.6375); // default to using analogWrite, mapping 400 to 255
   }
 
   if (speed == 0)
@@ -201,7 +202,7 @@ void DualVNH5019MotorShield::setM2Speed(int speed)
   if(_PWM2_REG) {
 	*_PWM2_REG = speed; // if the register is set then use the timers
   } else {
-	analogWrite(_PWM1,speed * 51 / 80); // default to using analogWrite, mapping 400 to 255
+	analogWrite(_PWM1,speed * 0.6375); // default to using analogWrite, mapping 400 to 255
   }
 	
   if (speed == 0)
@@ -243,7 +244,7 @@ void DualVNH5019MotorShield::setM1Brake(int brake)
   if(_PWM1_REG) {
 	*_PWM1_REG = brake; // if the register is set then use the timers
   } else {
-	analogWrite(_PWM1,brake * 51 / 80); // default to using analogWrite, mapping 400 to 255
+	analogWrite(_PWM1,brake * 0.6375); // default to using analogWrite, mapping 400 to 255
   }
 }
 
@@ -262,7 +263,7 @@ void DualVNH5019MotorShield::setM2Brake(int brake)
   if(_PWM1_REG) {
 	*_PWM1_REG = brake; // if the register is set then use the timers
   } else {
-	analogWrite(_PWM1,brake * 51 / 80); // default to using analogWrite, mapping 400 to 255
+	analogWrite(_PWM1,brake * 0.6375); // default to using analogWrite, mapping 400 to 255
   }
 }
 

--- a/DualVNH5019MotorShield/DualVNH5019MotorShield.cpp
+++ b/DualVNH5019MotorShield/DualVNH5019MotorShield.cpp
@@ -37,7 +37,7 @@ DualVNH5019MotorShield::DualVNH5019MotorShield(unsigned char INA1, unsigned char
 
 DualVNH5019MotorShield::DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, 
                                                unsigned char EN1DIAG1, unsigned char CS1, 
-                                               unsigned char INA2, unsigned char PWM1,
+                                               unsigned char PWM1, unsigned char INA2,
                                                unsigned char INB2, unsigned char EN2DIAG2, 
                                                unsigned char CS2, unsigned char PWM2)
 {

--- a/DualVNH5019MotorShield/DualVNH5019MotorShield.cpp
+++ b/DualVNH5019MotorShield/DualVNH5019MotorShield.cpp
@@ -175,7 +175,7 @@ void DualVNH5019MotorShield::setM1Speed(int speed)
   }
   if (speed > 400)  // Max PWM dutycycle
     speed = 400;
-	
+    
   if(_PWM1_REG) {
     *_PWM1_REG = speed;                // if the register is set then use the timer
   } else {

--- a/DualVNH5019MotorShield/DualVNH5019MotorShield.cpp
+++ b/DualVNH5019MotorShield/DualVNH5019MotorShield.cpp
@@ -18,13 +18,30 @@ DualVNH5019MotorShield::DualVNH5019MotorShield()
 }
 
 DualVNH5019MotorShield::DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, 
-											   unsigned char EN1DIAG1, unsigned char CS1, 
-                                               unsigned char INA2, unsigned char PWM1,
-											   unsigned char INB2, unsigned char EN2DIAG2, 
-											   unsigned char CS2, unsigned char PWM2)
+                                               unsigned char EN1DIAG1, unsigned char CS1, 
+                                               unsigned char INA2, unsigned char INB2, 
+                                               unsigned char EN2DIAG2, unsigned char CS2)
 {
   //Pin map
-  //PWM1 and PWM2 cannot be remapped because the library assumes PWM is on timer1
+  _INA1 = INA1;
+  _INB1 = INB1;
+  _EN1DIAG1 = EN1DIAG1;
+  _CS1 = CS1;
+  _PWM1 = 9;
+  _INA2 = INA2;
+  _INB2 = INB2;
+  _EN2DIAG2 = EN2DIAG2;
+  _CS2 = CS2;
+  _PWM2 = 10;
+}
+
+DualVNH5019MotorShield::DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, 
+                                               unsigned char EN1DIAG1, unsigned char CS1, 
+                                               unsigned char INA2, unsigned char PWM1,
+                                               unsigned char INB2, unsigned char EN2DIAG2, 
+                                               unsigned char CS2, unsigned char PWM2)
+{
+  //Pin map
   _INA1 = INA1;
   _INB1 = INB1;
   _EN1DIAG1 = EN1DIAG1;
@@ -68,16 +85,15 @@ void DualVNH5019MotorShield::init()
   // 16MHz / 1 (prescaler) / 2 (phase-correct) / 400 (top) = 20kHz
   if(_PWM1 == 9 || _PWM1 == 10 || _PWM2 == 9 || _PWM2 == 10)
   {
-	TCCR1A = 0;
+    TCCR1A = 0;
     if(_PWM1 == 9)       { TCCR1A |= _BV(COM1A1); _PWM1_REG = &OCR1A; }
-	else if(_PWM1 == 10) { TCCR1A |= _BV(COM1B1); _PWM1_REG = &OCR1B; }
-	
-	if(_PWM2 == 9)       { TCCR1A |= _BV(COM1A1); _PWM2_REG = &OCR1A; }
-	else if(_PWM2 == 10) { TCCR1A |= _BV(COM1B1); _PWM2_REG = &OCR1B; }
+    else if(_PWM1 == 10) { TCCR1A |= _BV(COM1B1); _PWM1_REG = &OCR1B; }
+    
+    if(_PWM2 == 9)       { TCCR1A |= _BV(COM1A1); _PWM2_REG = &OCR1A; }
+    else if(_PWM2 == 10) { TCCR1A |= _BV(COM1B1); _PWM2_REG = &OCR1B; }
   
-	//TCCR1A = _BV(COM1A1) + _BV(COM1B1);
-	TCCR1B = _BV(WGM13) + _BV(CS10);
-	ICR1 = 400;
+    TCCR1B = _BV(WGM13) | _BV(CS10);
+    ICR1 = 400;
   }
   /* ------------------------------- FOR THE MEGA ------------------------- */
   #elif defined(__AVR_ATmega2560__) 
@@ -85,73 +101,69 @@ void DualVNH5019MotorShield::init()
      _PWM2 == 11 || _PWM2 == 12 || _PWM2 == 13)
   {
     //timer1
-	TCCR1A = 0;
-	if(_PWM1 == 11)      { TCCR1A |= _BV(COM1A1); _PWM1_REG = &OCR1A; }
-	else if(_PWM1 == 12) { TCCR1A |= _BV(COM1B1); _PWM1_REG = &OCR1B; }
-	else if(_PWM1 == 13) { TCCR1A |= _BV(COM1C1); _PWM1_REG = &OCR1C; }
-	
-	if(_PWM2 == 11)      { TCCR1A |= _BV(COM1A1); _PWM2_REG = &OCR1A; }
-	else if(_PWM2 == 12) { TCCR1A |= _BV(COM1B1); _PWM2_REG = &OCR1B; }
-	else if(_PWM2 == 13) { TCCR1A |= _BV(COM1C1); _PWM2_REG = &OCR1C; }
-	
-	//TCCR1A = _BV(COM1A1) + _BV(COM1B1) + _BV(COM1C1);
-    TCCR1B = _BV(WGM13) + _BV(CS10);
+    TCCR1A = 0;
+    if(_PWM1 == 11)      { TCCR1A |= _BV(COM1A1); _PWM1_REG = &OCR1A; }
+    else if(_PWM1 == 12) { TCCR1A |= _BV(COM1B1); _PWM1_REG = &OCR1B; }
+    else if(_PWM1 == 13) { TCCR1A |= _BV(COM1C1); _PWM1_REG = &OCR1C; }
+    
+    if(_PWM2 == 11)      { TCCR1A |= _BV(COM1A1); _PWM2_REG = &OCR1A; }
+    else if(_PWM2 == 12) { TCCR1A |= _BV(COM1B1); _PWM2_REG = &OCR1B; }
+    else if(_PWM2 == 13) { TCCR1A |= _BV(COM1C1); _PWM2_REG = &OCR1C; }
+    
+    TCCR1B = _BV(WGM13) | _BV(CS10);
     ICR1 = 400;
   }
   else if(_PWM1 == 2 || _PWM1 == 3 || _PWM1 == 5 || 
           _PWM2 == 2 || _PWM2 == 3 || _PWM2 == 5)
   {
     //timer3
-	TCCR3A = 0;
-	if(_PWM1 == 5)      { TCCR3A |= _BV(COM3A1); _PWM1_REG = &OCR3A; }
-	else if(_PWM1 == 2) { TCCR3A |= _BV(COM3B1); _PWM1_REG = &OCR3B; }
-	else if(_PWM1 == 3) { TCCR3A |= _BV(COM3C1); _PWM1_REG = &OCR3C; }
-	
-	if(_PWM2 == 5)      { TCCR3A |= _BV(COM3A1); _PWM2_REG = &OCR3A; }
-	else if(_PWM2 == 2) { TCCR3A |= _BV(COM3B1); _PWM2_REG = &OCR3B; }
-	else if(_PWM2 == 3) { TCCR3A |= _BV(COM3C1); _PWM2_REG = &OCR3C; }
-	
-	//TCCR3A = _BV(COM3A1) + _BV(COM3B1) + _BV(COM3C1);
-    TCCR3B = _BV(WGM33) + _BV(CS30);
+    TCCR3A = 0;
+    if(_PWM1 == 5)      { TCCR3A |= _BV(COM3A1); _PWM1_REG = &OCR3A; }
+    else if(_PWM1 == 2) { TCCR3A |= _BV(COM3B1); _PWM1_REG = &OCR3B; }
+    else if(_PWM1 == 3) { TCCR3A |= _BV(COM3C1); _PWM1_REG = &OCR3C; }
+    
+    if(_PWM2 == 5)      { TCCR3A |= _BV(COM3A1); _PWM2_REG = &OCR3A; }
+    else if(_PWM2 == 2) { TCCR3A |= _BV(COM3B1); _PWM2_REG = &OCR3B; }
+    else if(_PWM2 == 3) { TCCR3A |= _BV(COM3C1); _PWM2_REG = &OCR3C; }
+    
+    TCCR3B = _BV(WGM33) | _BV(CS30);
     ICR3 = 400;
   }
   else if(_PWM1 == 6 || _PWM1 == 7 || _PWM1 == 8 || 
           _PWM2 == 6 || _PWM2 == 7 || _PWM2 == 8)
   {
     //timer4  
-	TCCR4A = 0;
-	if(_PWM1 == 6)      { TCCR4A |= _BV(COM4A1); _PWM1_REG = &OCR4A; }
-	else if(_PWM1 == 7) { TCCR4A |= _BV(COM4B1); _PWM1_REG = &OCR4B; }
-	else if(_PWM1 == 8) { TCCR4A |= _BV(COM4C1); _PWM1_REG = &OCR4C; }
-	
-	if(_PWM2 == 6)      { TCCR4A |= _BV(COM4A1); _PWM2_REG = &OCR4A; }
-	else if(_PWM2 == 7) { TCCR4A |= _BV(COM4B1); _PWM2_REG = &OCR4B; }
-	else if(_PWM2 == 8) { TCCR4A |= _BV(COM4C1); _PWM2_REG = &OCR4C; }
-	
-	//TCCR4A = _BV(COM4A1) + _BV(COM4B1) + _BV(COM4C1);
-    TCCR4B = _BV(WGM43) + _BV(CS40);
+    TCCR4A = 0;
+    if(_PWM1 == 6)      { TCCR4A |= _BV(COM4A1); _PWM1_REG = &OCR4A; }
+    else if(_PWM1 == 7) { TCCR4A |= _BV(COM4B1); _PWM1_REG = &OCR4B; }
+    else if(_PWM1 == 8) { TCCR4A |= _BV(COM4C1); _PWM1_REG = &OCR4C; }
+    
+    if(_PWM2 == 6)      { TCCR4A |= _BV(COM4A1); _PWM2_REG = &OCR4A; }
+    else if(_PWM2 == 7) { TCCR4A |= _BV(COM4B1); _PWM2_REG = &OCR4B; }
+    else if(_PWM2 == 8) { TCCR4A |= _BV(COM4C1); _PWM2_REG = &OCR4C; }
+    
+    TCCR4B = _BV(WGM43) | _BV(CS40);
     ICR4 = 400;
   }  
   else if(_PWM1 == 44 || _PWM1 == 45 || _PWM1 == 46 || 
           _PWM2 == 44 || _PWM2 == 45 || _PWM2 == 46)
   {
-	//timer5
-	TCCR5A = 0;
-	if(_PWM1 == 46)      { TCCR5A |= _BV(COM5A1); _PWM1_REG = &OCR5A; }
-	else if(_PWM1 == 45) { TCCR5A |= _BV(COM5B1); _PWM1_REG = &OCR5B; }
-	else if(_PWM1 == 44) { TCCR5A |= _BV(COM5C1); _PWM1_REG = &OCR5C; }
-	
-	if(_PWM2 == 46)      { TCCR5A |= _BV(COM5A1); _PWM2_REG = &OCR5A; }
-	else if(_PWM2 == 45) { TCCR5A |= _BV(COM5B1); _PWM2_REG = &OCR5B; }
-	else if(_PWM2 == 44) { TCCR5A |= _BV(COM5C1); _PWM2_REG = &OCR5C; }
-	
-	//TCCR5A = _BV(COM5A1) + _BV(COM5B1)51/ + _BV(COM5C1);
-    TCCR5B = _BV(WGM53) + _BV(CS50);
+    //timer5
+    TCCR5A = 0;
+    if(_PWM1 == 46)      { TCCR5A |= _BV(COM5A1); _PWM1_REG = &OCR5A; }
+    else if(_PWM1 == 45) { TCCR5A |= _BV(COM5B1); _PWM1_REG = &OCR5B; }
+    else if(_PWM1 == 44) { TCCR5A |= _BV(COM5C1); _PWM1_REG = &OCR5C; }
+    
+    if(_PWM2 == 46)      { TCCR5A |= _BV(COM5A1); _PWM2_REG = &OCR5A; }
+    else if(_PWM2 == 45) { TCCR5A |= _BV(COM5B1); _PWM2_REG = &OCR5B; }
+    else if(_PWM2 == 44) { TCCR5A |= _BV(COM5C1); _PWM2_REG = &OCR5C; }
+    
+    TCCR5B = _BV(WGM53) | _BV(CS50);
     ICR5 = 400;
   }
   #endif
 }
-// Set speed for motor 1, speed is a number betwenn -400 and 400
+// Set speed for motor 1, speed is a number between -400 and 400
 void DualVNH5019MotorShield::setM1Speed(int speed)
 {
   unsigned char reverse = 0;
@@ -163,10 +175,11 @@ void DualVNH5019MotorShield::setM1Speed(int speed)
   }
   if (speed > 400)  // Max PWM dutycycle
     speed = 400;
+	
   if(_PWM1_REG) {
-	*_PWM1_REG = speed; // if the register is set then use the timers
+    *_PWM1_REG = speed;                // if the register is set then use the timer
   } else {
-	analogWrite(_PWM1,speed * 0.6375); // default to using analogWrite, mapping 400 to 255
+    analogWrite(_PWM1,speed * 51/80); // default to using analogWrite, mapping 400 to 255
   }
 
   if (speed == 0)
@@ -200,11 +213,11 @@ void DualVNH5019MotorShield::setM2Speed(int speed)
     speed = 400;
 
   if(_PWM2_REG) {
-	*_PWM2_REG = speed; // if the register is set then use the timers
+    *_PWM2_REG = speed;                // if the register is set then use the timer
   } else {
-	analogWrite(_PWM1,speed * 0.6375); // default to using analogWrite, mapping 400 to 255
+    analogWrite(_PWM1,speed * 51/80); // default to using analogWrite, mapping 400 to 255
   }
-	
+    
   if (speed == 0)
   {
     digitalWrite(_INA2,LOW);   // Make the motor coast no
@@ -242,9 +255,9 @@ void DualVNH5019MotorShield::setM1Brake(int brake)
   digitalWrite(_INA1, LOW);
   digitalWrite(_INB1, LOW);
   if(_PWM1_REG) {
-	*_PWM1_REG = brake; // if the register is set then use the timers
+    *_PWM1_REG = brake;                // if the register is set then use the timer
   } else {
-	analogWrite(_PWM1,brake * 0.6375); // default to using analogWrite, mapping 400 to 255
+    analogWrite(_PWM1,brake * 51/80); // default to using analogWrite, mapping 400 to 255
   }
 }
 
@@ -261,9 +274,9 @@ void DualVNH5019MotorShield::setM2Brake(int brake)
   digitalWrite(_INA2, LOW);
   digitalWrite(_INB2, LOW);
   if(_PWM1_REG) {
-	*_PWM1_REG = brake; // if the register is set then use the timers
+    *_PWM1_REG = brake;                // if the register is set then use the timer
   } else {
-	analogWrite(_PWM1,brake * 0.6375); // default to using analogWrite, mapping 400 to 255
+    analogWrite(_PWM1,brake * 51/80); // default to using analogWrite, mapping 400 to 255
   }
 }
 

--- a/DualVNH5019MotorShield/DualVNH5019MotorShield.h
+++ b/DualVNH5019MotorShield/DualVNH5019MotorShield.h
@@ -8,11 +8,14 @@ class DualVNH5019MotorShield
   public:  
     // CONSTRUCTORS
     DualVNH5019MotorShield(); // Default pin selection.
+	DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, unsigned char EN1DIAG1, unsigned char CS1, 
+                           unsigned char INA2, unsigned char INB2, unsigned char EN2DIAG2, unsigned char CS2); //User-defined pin selection. 
+						   
     DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, 
 		                   unsigned char EN1DIAG1, unsigned char CS1, 
                            unsigned char INA2, unsigned char PWM1,
 						   unsigned char INB2, unsigned char EN2DIAG2, 
-						   unsigned char CS2, unsigned char PWM2); // User-defined pin selection. 
+						   unsigned char CS2, unsigned char PWM2); // User-defined pin selection, with PWM pins
     
     // PUBLIC METHODS
     void init(); // Initialize TIMER 1, set the PWM to 20kHZ. 

--- a/DualVNH5019MotorShield/DualVNH5019MotorShield.h
+++ b/DualVNH5019MotorShield/DualVNH5019MotorShield.h
@@ -13,7 +13,7 @@ class DualVNH5019MotorShield
                            
     DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, 
                            unsigned char EN1DIAG1, unsigned char CS1, 
-                           unsigned char INA2, unsigned char PWM1,
+                           unsigned char PWM1, unsigned char INA2,
                            unsigned char INB2, unsigned char EN2DIAG2, 
                            unsigned char CS2, unsigned char PWM2); // User-defined pin selection, with PWM pins
     

--- a/DualVNH5019MotorShield/DualVNH5019MotorShield.h
+++ b/DualVNH5019MotorShield/DualVNH5019MotorShield.h
@@ -8,14 +8,14 @@ class DualVNH5019MotorShield
   public:  
     // CONSTRUCTORS
     DualVNH5019MotorShield(); // Default pin selection.
-	DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, unsigned char EN1DIAG1, unsigned char CS1, 
+    DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, unsigned char EN1DIAG1, unsigned char CS1, 
                            unsigned char INA2, unsigned char INB2, unsigned char EN2DIAG2, unsigned char CS2); //User-defined pin selection. 
-						   
+                           
     DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, 
-		                   unsigned char EN1DIAG1, unsigned char CS1, 
+                           unsigned char EN1DIAG1, unsigned char CS1, 
                            unsigned char INA2, unsigned char PWM1,
-						   unsigned char INB2, unsigned char EN2DIAG2, 
-						   unsigned char CS2, unsigned char PWM2); // User-defined pin selection, with PWM pins
+                           unsigned char INB2, unsigned char EN2DIAG2, 
+                           unsigned char CS2, unsigned char PWM2); // User-defined pin selection, with PWM pins
     
     // PUBLIC METHODS
     void init(); // Initialize TIMER 1, set the PWM to 20kHZ. 
@@ -41,8 +41,8 @@ class DualVNH5019MotorShield
     unsigned char _PWM2;
     unsigned char _EN2DIAG2;
     unsigned char _CS2;
-	volatile uint16_t* _PWM1_REG;
-	volatile uint16_t* _PWM2_REG;
+    volatile uint16_t* _PWM1_REG;
+    volatile uint16_t* _PWM2_REG;
     
 };
 

--- a/DualVNH5019MotorShield/DualVNH5019MotorShield.h
+++ b/DualVNH5019MotorShield/DualVNH5019MotorShield.h
@@ -8,8 +8,11 @@ class DualVNH5019MotorShield
   public:  
     // CONSTRUCTORS
     DualVNH5019MotorShield(); // Default pin selection.
-    DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, unsigned char EN1DIAG1, unsigned char CS1, 
-                           unsigned char INA2, unsigned char INB2, unsigned char EN2DIAG2, unsigned char CS2); // User-defined pin selection. 
+    DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, 
+		                   unsigned char EN1DIAG1, unsigned char CS1, 
+                           unsigned char INA2, unsigned char PWM1,
+						   unsigned char INB2, unsigned char EN2DIAG2, 
+						   unsigned char CS2, unsigned char PWM2); // User-defined pin selection. 
     
     // PUBLIC METHODS
     void init(); // Initialize TIMER 1, set the PWM to 20kHZ. 
@@ -27,14 +30,16 @@ class DualVNH5019MotorShield
   private:
     unsigned char _INA1;
     unsigned char _INB1;
-    static const unsigned char _PWM1 = 9;
+    unsigned char _PWM1;
     unsigned char _EN1DIAG1;
     unsigned char _CS1;
     unsigned char _INA2;
     unsigned char _INB2;
-    static const unsigned char _PWM2 = 10;
+    unsigned char _PWM2;
     unsigned char _EN2DIAG2;
     unsigned char _CS2;
+	volatile uint16_t* _PWM1_REG;
+	volatile uint16_t* _PWM2_REG;
     
 };
 

--- a/README.textile
+++ b/README.textile
@@ -29,8 +29,7 @@ The demo ramps motor 1 from stopped to full speed forward, ramps down to full sp
 h2. Library Reference
 
 - @DualVNH5019MotorShield()@ := Default constructor, selects the default pins as connected by the motor shield.
-- @DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, unsigned char EN1DIAG1, unsigned char CS1, unsigned char PWM1
-@unsigned char INA2, unsigned char INB2, unsigned char EN2DIAG2, unsigned char CS2, unsigned char PWM2)@ := Alternate constructor for shield connections remapped by user. Choice of PWM pins depend on whether 16-bit timers will be used or regular 8-bit analogWrite will be used.
+- @DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, unsigned char EN1DIAG1, unsigned char CS1, unsigned char PWM1, unsigned char INA2, unsigned char INB2, unsigned char EN2DIAG2, unsigned char CS2, unsigned char PWM2)@ := Alternate constructor for shield connections remapped by user. Choice of PWM pins depend on whether 16-bit timers will be used or regular 8-bit analogWrite will be used.
 
 - @void init()@ := Initialize pinModes and any timers that will be used.
 

--- a/README.textile
+++ b/README.textile
@@ -1,7 +1,7 @@
 h1. Arduino library for the Pololu Dual VNH5019 Motor Driver Shield
 
-Version: 1.3.0
-Release Date: 2014-05-03
+Version: 1.2.3
+Release Date: 2014-03-24
 "www.pololu.com":http://www.pololu.com/
 
 h2. Summary
@@ -29,9 +29,11 @@ The demo ramps motor 1 from stopped to full speed forward, ramps down to full sp
 h2. Library Reference
 
 - @DualVNH5019MotorShield()@ := Default constructor, selects the default pins as connected by the motor shield.
+- @DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, unsigned char EN1DIAG1, unsigned char CS1,@
+@unsigned char INA2, unsigned char INB2, unsigned char EN2DIAG2, unsigned char CS2)@ := Alternate constructor for shield connections remapped by user. PWM1 and PWM2 cannot be remapped because the library assumes PWM is on timer1.
 - @DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, unsigned char EN1DIAG1, unsigned char CS1, unsigned char PWM1, unsigned char INA2, unsigned char INB2, unsigned char EN2DIAG2, unsigned char CS2, unsigned char PWM2)@ := Alternate constructor for shield connections remapped by user. Choice of PWM pins depend on whether 16-bit timers will be used or regular 8-bit analogWrite will be used.
 
-- @void init()@ := Initialize pinModes and any timers that will be used.
+- @void init()@ := Initialize pinModes and any timers that will be used (timer1 by default).
 
 - @void setM1Speed(int speed)@ := Set speed and direction for motor 1. Speed should be between -400 and 400. 400 corresponds to motor current flowing from M1A to M1B. -400 corresponds to motor current flowing from M1B to M1A.  0 corresponds to full coast.
 - @void setM2Speed(int speed)@ := Set speed and direction for motor 2. Speed should be between -400 and 400. 400 corresponds to motor current flowing from M2A to M2B. -400 corresponds to motor current flowing from M2B to M2A.  0 corresponds to full coast.
@@ -49,7 +51,6 @@ h2. Library Reference
 
 h2. Version History
 
-* 1.3.0 (2014-05-03): Added support for ATmega2560 with support for use of any PWM pins, a 16-bit timer used if possible.
 * 1.2.3 (2014-03-24): Added 20 kHz PWM support for ATmega32U4. Thanks blacksound.
 * 1.2.2 (2014-03-18): Add keywords.txt file. Thanks eatonphil.
 * 1.2.1 (2013-01-06): Fixed a bug in setM2Speed that was introduced in 1.2.0.

--- a/README.textile
+++ b/README.textile
@@ -1,7 +1,7 @@
 h1. Arduino library for the Pololu Dual VNH5019 Motor Driver Shield
 
-Version: 1.2.3
-Release Date: 2014-03-24
+Version: 1.3.0
+Release Date: 2014-05-03
 "www.pololu.com":http://www.pololu.com/
 
 h2. Summary
@@ -29,10 +29,10 @@ The demo ramps motor 1 from stopped to full speed forward, ramps down to full sp
 h2. Library Reference
 
 - @DualVNH5019MotorShield()@ := Default constructor, selects the default pins as connected by the motor shield.
-- @DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, unsigned char EN1DIAG1, unsigned char CS1,@
-@unsigned char INA2, unsigned char INB2, unsigned char EN2DIAG2, unsigned char CS2)@ := Alternate constructor for shield connections remapped by user. PWM1 and PWM2 cannot be remapped because the library assumes PWM is on timer1.
+- @DualVNH5019MotorShield(unsigned char INA1, unsigned char INB1, unsigned char EN1DIAG1, unsigned char CS1, unsigned char PWM1
+@unsigned char INA2, unsigned char INB2, unsigned char EN2DIAG2, unsigned char CS2, unsigned char PWM2)@ := Alternate constructor for shield connections remapped by user. Choice of PWM pins depend on whether 16-bit timers will be used or regular 8-bit analogWrite will be used.
 
-- @void init()@ := Initialize pinModes and timer1.
+- @void init()@ := Initialize pinModes and any timers that will be used.
 
 - @void setM1Speed(int speed)@ := Set speed and direction for motor 1. Speed should be between -400 and 400. 400 corresponds to motor current flowing from M1A to M1B. -400 corresponds to motor current flowing from M1B to M1A.  0 corresponds to full coast.
 - @void setM2Speed(int speed)@ := Set speed and direction for motor 2. Speed should be between -400 and 400. 400 corresponds to motor current flowing from M2A to M2B. -400 corresponds to motor current flowing from M2B to M2A.  0 corresponds to full coast.
@@ -50,6 +50,7 @@ h2. Library Reference
 
 h2. Version History
 
+* 1.3.0 (2014-05-03): Added support for ATmega2560 with support for use of any PWM pins, a 16-bit timer used if possible.
 * 1.2.3 (2014-03-24): Added 20 kHz PWM support for ATmega32U4. Thanks blacksound.
 * 1.2.2 (2014-03-18): Add keywords.txt file. Thanks eatonphil.
 * 1.2.1 (2013-01-06): Fixed a bug in setM2Speed that was introduced in 1.2.0.


### PR DESCRIPTION
Hello, I am using this library to drive motors on an "Antenna Tracker" project. We use the Arduino mega however and wanted to use the same accurate PWM. So I modified the library to allow for use of any PWM pins. It checks if a timer is compatible with the PWM pins selected and if so it uses the accurate PWM otherwise it just uses analogWrite. It should also be fully compatible with the previous versions of the library.

It is not fully test for all the pins on the mega 2560 but it works perfectly using Timer5 for the pins we broke out to the driver board (44 and 45 I believe). It should be exactly the same for the other timer pins so there is no reason it wouldn't work, just want to make it clear that it wasn't fully tested.

Hope you can use my additions!
