### PR TITLE
Add note about recommended pins to avoid with additional libraries

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -19,6 +19,7 @@ h3. Hardware
 The Dual VNH5019 Motor Driver Shield can be purchased on "Pololu's website":http://www.pololu.com/catalog/product/2507. See the "motor shield user's guide":http://www.pololu.com/docs/0J49 for more details.
 * if using other libraries (like the servo library), you need cut and move the PWM pins on the shield
 ** for use with the Uno, for best results avoid using pins 9,10 for PWM
+** use with the Arduino Mega avoid using pins 9, 10, 44, 45, or 46 for PWM
 ** information on how to move the pins used by the pololu DualVNH5019MotorShield See the "motor shield user's guide":http://www.pololu.com/docs/0J49 for details
 
 h2. Example Program

--- a/README.textile
+++ b/README.textile
@@ -17,10 +17,9 @@ Download the archive from "GitHub":https://github.com/pololu/Dual-VNH5019-Motor-
 h3. Hardware
 
 The Dual VNH5019 Motor Driver Shield can be purchased on "Pololu's website":http://www.pololu.com/catalog/product/2507. See the "motor shield user's guide":http://www.pololu.com/docs/0J49 for more details.
-– if using other libraries (like the servo library), you need cut and move the PWM pins on the shield
-  - for use with the Uno, for best results avoid using pins 9,10 for PWM
-  - use with the Arduino Mega avoid using pins 9, 10, 44, 45, or 46 for PWM
-  – information on how to move the pins used by the pololu DualVNH5019MotorShield See the "motor shield user's guide":http://www.pololu.com/docs/0J49 for details
+* if using other libraries (like the servo library), you need cut and move the PWM pins on the shield
+** for use with the Uno, for best results avoid using pins 9,10 for PWM
+** information on how to move the pins used by the pololu DualVNH5019MotorShield See the "motor shield user's guide":http://www.pololu.com/docs/0J49 for details
 
 h2. Example Program
 

--- a/README.textile
+++ b/README.textile
@@ -17,7 +17,8 @@ Download the archive from "GitHub":https://github.com/pololu/Dual-VNH5019-Motor-
 h3. Hardware
 
 The Dual VNH5019 Motor Driver Shield can be purchased on "Pololu's website":http://www.pololu.com/catalog/product/2507. See the "motor shield user's guide":http://www.pololu.com/docs/0J49 for more details.
-– if using other libraries (like the servo library), you need cut and move the PWM pins on the shield for use with the Uno, for best results avoid using pins 9,10 for PWM
+– if using other libraries (like the servo library), you need cut and move the PWM pins on the shield
+  - for use with the Uno, for best results avoid using pins 9,10 for PWM
   - use with the Arduino Mega avoid using pins 9, 10, 44, 45, or 46 for PWM
   – information on how to move the pins used by the pololu DualVNH5019MotorShield See the "motor shield user's guide":http://www.pololu.com/docs/0J49 for details
 

--- a/README.textile
+++ b/README.textile
@@ -17,6 +17,9 @@ Download the archive from "GitHub":https://github.com/pololu/Dual-VNH5019-Motor-
 h3. Hardware
 
 The Dual VNH5019 Motor Driver Shield can be purchased on "Pololu's website":http://www.pololu.com/catalog/product/2507. See the "motor shield user's guide":http://www.pololu.com/docs/0J49 for more details.
+– if using other libraries (like the servo library), you need cut and move the PWM pins on the shield for use with the Uno, for best results avoid using pins 9,10 for PWM
+  - use with the Arduino Mega avoid using pins 9, 10, 44, 45, or 46 for PWM
+  – information on how to move the pins used by the pololu DualVNH5019MotorShield See the "motor shield user's guide":http://www.pololu.com/docs/0J49 for details
 
 h2. Example Program
 


### PR DESCRIPTION
reference issue #7
some libraries and functions conflict with PWM use, avoiding PWM pins on Timer 1 on the uno or Timer 5,or 2,on the mega

- UNO: when you use the Servo Library you can’t use PWM on Pin 9, 10
- MEGA: it is a little bit more difficult
  - For the first 12 servos timer 5 will be used (losing PWM on Pins 44,45,46)
  - For 13-24 servos timer 5 and 1 will be used (losing PWM on Pins 11,12,44,45,46)
  - For 25-36 servos timer 5, 1 and 3 will be used (losing PWM on Pins 2,3,5,11,12,44,45,46)
  - For 37-48 servos all 16bit timers 5,1,3 and 4 will be used (losing all PWM pins).