### PR TITLE
Add continuous integrated testing using Travis CI and PlatformIO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+# Test build your arduino libraries with travis and Arturo
+language: python
+python:
+ - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+ directories:
+  - "~/.platformio"
+
+env:
+ - PLATFORMIO_CI_SRC=DualVNH5019MotorShield/examples/Demo/Demo.ino
+
+install:
+ - pip install -U platformio
+
+script:
+ - platformio ci --lib="DualVNH5019MotorShield" --board=uno --board=megaatmega2560

--- a/README.textile
+++ b/README.textile
@@ -2,6 +2,7 @@ h1. Arduino library for the Pololu Dual VNH5019 Motor Driver Shield
 
 Version: 1.2.3
 Release Date: 2014-03-24
+!https://travis-ci.org/pololu/dual-vnh5019-motor-shield.svg?branch=master!:https://travis-ci.org/pololu/dual-vnh5019-motor-shield
 "www.pololu.com":http://www.pololu.com/
 
 h2. Summary


### PR DESCRIPTION
Add continuous integrated testing using [Travis CI](https://travis-ci.org) and [PlatformIO](https://github.com/platformio/platformio). Requires signing up for the free service [details can be found in the docs](https://docs.travis-ci.com/)

This is a low-level continuous integrated testing the ensures the library functions and PR's are valid.
The low-level Testing verifies the library against the supplied example demo.ino

You can see the passing build with this link to my Travis CI branch which has been configured to test https://travis-ci.org/photodude/DualVNH5019MotorShieldMod3/builds/151091859

Currently, this only tests against 2 boards (uno and megaatmega2560) additional boards can be added for tested. (example with more boards https://travis-ci.org/photodude/DualVNH5019MotorShieldMod3/builds/151090810)